### PR TITLE
Set login form to post, in case js errors prevent submit cancelation

### DIFF
--- a/app/source/templates/login.hbs
+++ b/app/source/templates/login.hbs
@@ -1,6 +1,6 @@
 {{> header}}
 
-<form class="login-form" autocomplete="off" data-redirect="{{redirect}}">
+<form class="login-form" method="post" autocomplete="off" data-redirect="{{redirect}}">
     <div class="text-center mb-2">
         <a href="https://www.leafpub.org/" target="_blank">
             <!--img class="logo" src="{{#if @settings.logo}}{{img @settings.logo}}" style="width: 100%;"{{else}}{{url 'source/assets/img/logo-color.svg'}}"{{/if}}-->


### PR DESCRIPTION
After an update from 1.0.0 to 1.2.0-beta7 the jQuery script was missing. (I had it set to load from local)
This made the login form submit via GET and thus showed my password in the URI. With this change it would mitigate this data leakage (bystanders seeing my password)

### Pull Request Summary

Only added post as method to the login form
